### PR TITLE
Add Window.GetFlags

### DIFF
--- a/Window.go
+++ b/Window.go
@@ -19,7 +19,8 @@ func SingleWindow() *WindowWidget {
 				imgui.WindowFlagsNoCollapse|
 				imgui.WindowFlagsNoScrollbar|
 				imgui.WindowFlagsNoMove|
-				imgui.WindowFlagsNoResize).
+				imgui.WindowFlagsNoResize|
+				imgui.WindowFlagsNoBringToFrontOnFocus).
 		Size(size[0], size[1])
 }
 

--- a/Window.go
+++ b/Window.go
@@ -83,6 +83,11 @@ func (w *WindowWidget) Flags(flags WindowFlags) *WindowWidget {
 	return w
 }
 
+// GetFlags gets window flags.
+func (w *WindowWidget) GetFlags() WindowFlags {
+	return w.flags
+}
+
 // Size sets window size
 // NOTE: size can be changed by user, if you want to prevent
 // user from changing window size, use NoResize flag.


### PR DESCRIPTION
It's useful, when using `SingleWindow` and some other flags